### PR TITLE
fix: prevent default action for event listeners in read only components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@authorizerdev/authorizer-svelte",
-	"version": "0.0.1-beta5",
+	"version": "0.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@authorizerdev/authorizer-svelte",
-			"version": "0.0.1-beta5",
+			"version": "0.1.0",
 			"license": "MIT",
 			"dependencies": {
 				"@authorizerdev/authorizer-js": "^1.1.0"

--- a/src/lib/components/PasswordStrengthIndicator.svelte
+++ b/src/lib/components/PasswordStrengthIndicator.svelte
@@ -58,27 +58,63 @@
 		</p>
 		<StyledFlex flexDirection="column">
 			<StyledFlex justifyContent="flex-start" alignItems="center" width="100%">
-				<input readOnly type="checkbox" checked={componentState.hasSixChar} />
+				<input
+					readOnly
+					on:click|preventDefault
+					on:keydown|preventDefault
+					type="checkbox"
+					checked={componentState.hasSixChar}
+				/>
 				<div style="margin-left: 5px;">At least 6 characters</div>
 			</StyledFlex>
 			<StyledFlex justifyContent="flex-start" alignItems="center" width="100%">
-				<input readOnly type="checkbox" checked={componentState.hasLowerCase} />
+				<input
+					readOnly
+					on:click|preventDefault
+					on:keydown|preventDefault
+					type="checkbox"
+					checked={componentState.hasLowerCase}
+				/>
 				<div style="margin-left: 5px;">At least 1 lowercase letter</div>
 			</StyledFlex>
 			<StyledFlex justifyContent="flex-start" alignItems="center" width="100%">
-				<input readOnly type="checkbox" checked={componentState.hasUpperCase} />
+				<input
+					readOnly
+					on:click|preventDefault
+					on:keydown|preventDefault
+					type="checkbox"
+					checked={componentState.hasUpperCase}
+				/>
 				<div style="margin-left: 5px;">At least 1 uppercase letter</div>
 			</StyledFlex>
 			<StyledFlex justifyContent="flex-start" alignItems="center" width="100%">
-				<input readOnly type="checkbox" checked={componentState.hasNumericChar} />
+				<input
+					readOnly
+					on:click|preventDefault
+					on:keydown|preventDefault
+					type="checkbox"
+					checked={componentState.hasNumericChar}
+				/>
 				<div style="margin-left: 5px;">At least 1 numeric character</div>
 			</StyledFlex>
 			<StyledFlex justifyContent="flex-start" alignItems="center" width="100%">
-				<input readOnly type="checkbox" checked={componentState.hasSpecialChar} />
+				<input
+					readOnly
+					on:click|preventDefault
+					on:keydown|preventDefault
+					type="checkbox"
+					checked={componentState.hasSpecialChar}
+				/>
 				<div style="margin-left: 5px;">At least 1 special character</div>
 			</StyledFlex>
 			<StyledFlex justifyContent="flex-start" alignItems="center" width="100%">
-				<input readOnly type="checkbox" checked={componentState.maxThirtySixChar} />
+				<input
+					readOnly
+					on:click|preventDefault
+					on:keydown|preventDefault
+					type="checkbox"
+					checked={componentState.maxThirtySixChar}
+				/>
 				<div style="margin-left: 5px;">Maximum 36 characters</div>
 			</StyledFlex>
 		</StyledFlex>


### PR DESCRIPTION
#### What does this PR do?

- Prevent default action for event listeners in checkboxes - `PasswordStrengthIndicator`

#### Which issue(s) does this PR fix?

- Resolves the issue - #24 

#### If this PR affects any API reference documentation, please share the updated endpoint references
