### PR TITLE
BUGFIX: bump authorizer-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@authorizerdev/authorizer-svelte",
-	"version": "0.1.9",
+	"version": "0.1.10",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@authorizerdev/authorizer-svelte",
-			"version": "0.1.9",
+			"version": "0.1.10",
 			"license": "MIT",
 			"dependencies": {
 				"@authorizerdev/authorizer-js": "^1.2.18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.9",
 			"license": "MIT",
 			"dependencies": {
-				"@authorizerdev/authorizer-js": "^1.2.6"
+				"@authorizerdev/authorizer-js": "^1.2.18"
 			},
 			"devDependencies": {
 				"@playwright/test": "^1.25.0",
@@ -32,9 +32,9 @@
 			}
 		},
 		"node_modules/@authorizerdev/authorizer-js": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-js/-/authorizer-js-1.2.6.tgz",
-			"integrity": "sha512-9+9phHUMF+AeDM0y+XQvIRDoerOXnQ1vfTfYN6KxWN1apdrkAd9nzS1zUsA2uJSnX3fFZOErn83GjbYYCYF1BA==",
+			"version": "1.2.18",
+			"resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-js/-/authorizer-js-1.2.18.tgz",
+			"integrity": "sha512-9j5U/4lqaaEcG78Zli+TtLJ0migSKhFwnXXunulAGTZOzQSTCJ/CSSPip5wWNa/Mkr6gdEMwk1HYfhIdk2A9Mg==",
 			"dependencies": {
 				"cross-fetch": "^3.1.5"
 			},
@@ -3634,9 +3634,9 @@
 	},
 	"dependencies": {
 		"@authorizerdev/authorizer-js": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-js/-/authorizer-js-1.2.6.tgz",
-			"integrity": "sha512-9+9phHUMF+AeDM0y+XQvIRDoerOXnQ1vfTfYN6KxWN1apdrkAd9nzS1zUsA2uJSnX3fFZOErn83GjbYYCYF1BA==",
+			"version": "1.2.18",
+			"resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-js/-/authorizer-js-1.2.18.tgz",
+			"integrity": "sha512-9j5U/4lqaaEcG78Zli+TtLJ0migSKhFwnXXunulAGTZOzQSTCJ/CSSPip5wWNa/Mkr6gdEMwk1HYfhIdk2A9Mg==",
 			"requires": {
 				"cross-fetch": "^3.1.5"
 			}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@authorizerdev/authorizer-svelte",
-	"version": "0.1.9",
+	"version": "0.1.10",
 	"license": "MIT",
 	"author": "Lakhan Samani",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@authorizerdev/authorizer-js": "^1.2.6"
+		"@authorizerdev/authorizer-js": "^1.2.18"
 	}
 }


### PR DESCRIPTION
#### What does this PR do?
I bumped authorizer-js version. 

#### Which issue(s) does this PR fix?

After latest updates to authrorizer this repo does not work. 

![Screenshot 2023-12-03 at 19 46 26](https://github.com/authorizerdev/authorizer-svelte/assets/17649698/d1523a86-20ba-4383-b8de-76f0491d46b9)
