### PR TITLE
fix(security): validate redirect_uri to prevent open redirect attacks

### DIFF
--- a/src/lib/components/AuthorizerResetPassword.svelte
+++ b/src/lib/components/AuthorizerResetPassword.svelte
@@ -7,6 +7,20 @@
 	import PasswordStrengthIndicator from './PasswordStrengthIndicator.svelte';
 	import type { AuthorizerState } from '../types';
 
+	function isValidRedirectUri(uri: string, allowedRedirect?: string): boolean {
+		try {
+			const url = new URL(uri, window.location.origin);
+			if (url.origin === window.location.origin) return true;
+			if (allowedRedirect) {
+				const allowed = new URL(allowedRedirect);
+				if (url.origin === allowed.origin) return true;
+			}
+			return false;
+		} catch {
+			return false;
+		}
+	}
+
 	export let onReset: Function | undefined = undefined;
 
 	let state: AuthorizerState;
@@ -54,17 +68,25 @@
 	const onSubmit = async () => {
 		componentState.loading = true;
 		try {
-			const res = await state.authorizerRef.resetPassword({
+			const { data: res, errors } = await state.authorizerRef.resetPassword({
 				token,
 				password: formData.password,
 				confirm_password: formData.confirmPassword
 			});
 			componentState.loading = false;
+			if (errors && errors.length) {
+				componentState.error = errors[0].message;
+				return;
+			}
 			componentState.error = null;
 			if (onReset) {
 				onReset(res);
 			} else {
-				window.location.href = redirect_uri || state.config.redirectURL || window.location.origin;
+					const fallback = state.config.redirectURL || window.location.origin;
+				const target = redirect_uri && isValidRedirectUri(redirect_uri, state.config.redirectURL)
+					? redirect_uri
+					: fallback;
+				window.location.href = target;
 			}
 		} catch (error: any) {
 			componentState.loading = false;


### PR DESCRIPTION
## Summary
- Added `isValidRedirectUri()` validation in `AuthorizerResetPassword.svelte` — redirect_uri is now validated against same-origin and configured redirect URL before use
- Prevents attacker-controlled redirect_uri from redirecting users to malicious sites after password reset

## Companion PRs
- authorizerdev/authorizer#579 (main login app fix)
- authorizerdev/authorizer-react#52 (React SDK fix)

## Test plan
- [ ] Verify password reset redirects work for same-origin URLs
- [ ] Verify cross-origin redirect to evil.com is blocked
- [ ] Verify configured redirect_uri still works